### PR TITLE
changed the style of version string to `major_ver.middle_ver.minor_ve…

### DIFF
--- a/pints/_version.py
+++ b/pints/_version.py
@@ -351,10 +351,12 @@ def render_pep440_pre(pieces):
     if pieces["closest-tag"]:
         rendered = pieces["closest-tag"]
         if pieces["distance"]:
-            rendered += ".post0.dev%d" % pieces["distance"]
+            rendered += ".%d" % pieces["distance"]
+        else:
+            rendered += ".0"
     else:
         # exception #1
-        rendered = "0.post0.dev%d" % pieces["distance"]
+        rendered = "0.%d" % pieces["distance"]
     return rendered
 
 

--- a/scripts/pints_caller
+++ b/scripts/pints_caller
@@ -691,7 +691,7 @@ def check_window_chromosome(rc_file, output_file, strand_sign, chromosome_name, 
             else:
                 suggest_val = search_grid[-1]
                 
-            if bkg_mu_threshold < 0.5:
+            if bkg_mu_threshold < 0.5 and len(all_peak_mus) > 1000:
                 logger.warning((
                     "Current min value for local background density is %.3f, "
                     "please consider increasing the value of --min-mu-percent "

--- a/versioneer.py
+++ b/versioneer.py
@@ -762,10 +762,12 @@ def render_pep440_pre(pieces):
     if pieces["closest-tag"]:
         rendered = pieces["closest-tag"]
         if pieces["distance"]:
-            rendered += ".post0.dev%%d" %% pieces["distance"]
+            rendered += ".%%d" %% pieces["distance"]
+        else:
+            rendered += ".0"
     else:
         # exception #1
-        rendered = "0.post0.dev%%d" %% pieces["distance"]
+        rendered = "0.%%d" %% pieces["distance"]
     return rendered
 
 
@@ -1270,10 +1272,12 @@ def render_pep440_pre(pieces):
     if pieces["closest-tag"]:
         rendered = pieces["closest-tag"]
         if pieces["distance"]:
-            rendered += ".post0.dev%d" % pieces["distance"]
+            rendered += ".%d" % pieces["distance"]
+        else:
+            rendered += ".0"
     else:
         # exception #1
-        rendered = "0.post0.dev%d" % pieces["distance"]
+        rendered = "0.%d" % pieces["distance"]
     return rendered
 
 


### PR DESCRIPTION
bumped versions to 1.1.x.
changed the style of version string to `major_ver.middle_ver.minor_ver`. The first two vers are defined by tags, the minor_ver will be inferred automatically from commit distance.