### PR TITLE
[Changed]: PINTS now includes signals from all chromosomes by default…

### DIFF
--- a/pints/__init__.py
+++ b/pints/__init__.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-#  PINTS: Peak Identifier for Nascent Transcripts Starts
-#  Copyright (c) 2019-2024 Yu Lab.
+#  PINTS: Peak Identifier for Nascent Transcript Starts
+#  Copyright (c) 2019-2025 Yu Lab.
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/pints/extension_engine.py
+++ b/pints/extension_engine.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 # coding=utf-8
 
-#  PINTS: Peak Identifier for Nascent Transcripts Starts
-#  Copyright (c) 2019-2024 Yu Lab.
+#  PINTS: Peak Identifier for Nascent Transcript Starts
+#  Copyright (c) 2019-2025 Yu Lab.
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/pints/qc_engine.py
+++ b/pints/qc_engine.py
@@ -1,8 +1,8 @@
 # coding=utf-8
 import os.path
 
-#  PINTS: Peak Identifier for Nascent Transcripts Starts
-#  Copyright (c) 2019-2024 Yu Lab.
+#  PINTS: Peak Identifier for Nascent Transcript Starts
+#  Copyright (c) 2019-2025 Yu Lab.
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/scripts/pints_boundary_extender
+++ b/scripts/pints_boundary_extender
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-#  PINTS: Peak Identifier for Nascent Transcripts Starts
-#  Copyright (c) 2019-2024 Yu Lab.
+#  PINTS: Peak Identifier for Nascent Transcript Starts
+#  Copyright (c) 2019-2025 Yu Lab.
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/scripts/pints_caller
+++ b/scripts/pints_caller
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 # coding=utf-8
 
-#  PINTS: Peak Identifier for Nascent Transcripts Starts
-#  Copyright (c) 2019-2024 Yu Lab.
+#  PINTS: Peak Identifier for Nascent Transcript Starts
+#  Copyright (c) 2019-2025 Yu Lab.
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -82,6 +82,9 @@ if __name__ == "__main__":
                        required=False, default=False,
                        help="Set this switch if reads in this library represent the reverse complement of "
                             "RNAs, like PROseq")
+    group.add_argument("--dont-merge-reps", action="store_false", dest="merge_replicates",
+                       required=False, default=True,
+                       help="Don't merge replicates (this is the default setting for the previous versions)")
     group.add_argument("-f", "--filters", action="store", type=str, nargs="*", default=[],
                        help="reads from chromosomes whose names contain any matches in filters will be ignored")
 
@@ -109,7 +112,6 @@ if __name__ == "__main__":
                             "to run extra test")
     group.add_argument("--max-window-size", action="store", dest="window_size_threshold",
                        type=int, required=False, default=2000, help="max size of divergent windows")
-                       
     group.add_argument("--remove-sticks", action="store_false", dest="keep_sticks",
                        required=False, default=True,
                        help="Set this switch to remove stick-like peaks (signal on a single position)")
@@ -170,6 +172,17 @@ if __name__ == "__main__":
     group.add_argument("--disable-small", action="store_true", required=False, default=False,
                        help="Set this switch to prevent PINTS from reporting very short peaks"
                             "(shorter than --small-peak-threshold)")
+    group.add_argument("--sensitive", dest="sensitive", action="store_true", required=False,
+                       help="Set this switch to enable more sensitive peak calling")
+    group.add_argument("--fc", action="store", dest="fc_cutoff",
+                       type=float, required=False, default=1.5,
+                       help="When using the sensitive mode, this sets the cutoff for applying the likelihood ratio test.")
+    group.add_argument("--init-dens-cutoff", action="store", dest="init_dens_cutoff",
+                       type=float, required=False, default=0.25,
+                       help="Peaks with initiation density lower than this cutoff will not be tested in the sensitive mode.")
+    group.add_argument("--init-height-cutoff", action="store", dest="init_height_cutoff",
+                       type=int, required=False, default=4,
+                       help="Peaks with initiation summit lower than this cutoff will not be tested in the sensitive mode.")
 
     group = parser.add_argument_group("Other")
     group.add_argument("--epig-annotation", action="store", dest="epig_annotation", type=str, required=False,
@@ -178,7 +191,7 @@ if __name__ == "__main__":
     group.add_argument("--relaxed-fdr-target", action="store", dest="relaxed_fdr_target", default=0.2,
                        type=float, required=False, help="Relaxed FDR cutoff for TREs overlap with epigenomic annotations")
     group.add_argument("--chromosome-start-with", action="store", dest="chromosome_startswith",
-                       type=str, required=False, default="chr",
+                       type=str, required=False, default="",
                        help="Only keep reads mapped to chromosomes with this prefix")
     group.add_argument("--dont-output-chrom-size", action="store_false", dest="output_chrom_size",
                        required=False, default=True,

--- a/scripts/pints_counter
+++ b/scripts/pints_counter
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 # coding=utf-8
 
-#  PINTS: Peak Identifier for Nascent Transcripts Starts
-#  Copyright (c) 2019-2024 Yu Lab.
+#  PINTS: Peak Identifier for Nascent Transcript Starts
+#  Copyright (c) 2019-2025 Yu Lab.
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -31,7 +31,7 @@ pints_de -b C1_1_bidirectional_peaks.bed C2_1_bidirectional_peaks.bed \
 """
 
 
-def prepare_regions(primary_regions, additional_regions=None, min_dist=0):
+def prepare_regions(primary_regions, additional_regions=None, max_dist=0):
     """
     Prepare regions based on primary and additional regions in each library.
 
@@ -41,7 +41,7 @@ def prepare_regions(primary_regions, additional_regions=None, min_dist=0):
         A list/tuple of primary regions (e.g. bidirectional peaks)
     additional_regions : Optional[Sequence[str]]
         A list/tuple of additional regions (e.g. unidirectional peaks)
-    min_dist : int
+    max_dist : int
         Maximum distance between features allowed for features to be merged.
         Default is 0 (overlapping & book-ended features are merged.)
 
@@ -56,7 +56,7 @@ def prepare_regions(primary_regions, additional_regions=None, min_dist=0):
     merged_regions = pybedtools.BedTool.cat(
         *[pybedtools.BedTool(f) for f in all_files], postmerge=False
     ).sort().merge(
-        d=min_dist).saveas()
+        d=max_dist).saveas()
     return merged_regions
 
 
@@ -143,7 +143,7 @@ norm_counts <- counts(dds, normalized=TRUE)
 
 def main(bidirectional_calls, pl_bws, conditions, replications, save_to,
          unidirectional_calls=None, mn_bws=None, condition_names=None,
-         print_deseq2=True):
+         max_dist=0, print_deseq2=True):
     """
 
     Parameters
@@ -170,6 +170,8 @@ def main(bidirectional_calls, pl_bws, conditions, replications, save_to,
         Signal files for the reverse strand
     condition_names : Optional[Sequence[str]]
         Names of conditions
+    max_dist : int
+        Maximum distance between TRES allowed for TREs to be merged.
     print_deseq2 : bool
         Print boilerplate for running DESeq2
 
@@ -200,7 +202,7 @@ def main(bidirectional_calls, pl_bws, conditions, replications, save_to,
         condition_names = ["Cond{}".format(i) for i in range(1, per_sample_conditions[0] + 1)]
 
     # actual logic
-    union_of_regions = prepare_regions(bidirectional_calls, unidirectional_calls)
+    union_of_regions = prepare_regions(bidirectional_calls, unidirectional_calls, max_dist=max_dist)
     labels = ["{}_{}".format(c, replications[i]) for i, c in enumerate(conditions)]
     counts_mat_dict = dict()
 
@@ -236,6 +238,11 @@ if __name__ == "__main__":
     parser.add_argument("-r", "--replicates", nargs="+", type=int, required=True,
                         help="Ordinal numbers of replications. For example, if you have three replicates for condA, "
                              "you need to type `1 2 3` here.")
+    parser.add_argument("--max-dist", type=int, required=False, default=0,
+                        help="Maximum distance between TRES allowed for TREs to be merged. "
+                             "Default 0: overlapping & book-ended features are merged. "
+                             "Negative values enforce the number of b.p. required for overlap. "
+                             "See bedtools manual for more details.")
     parser.add_argument("-s", "--save-to", type=str, required=True)
     parser.add_argument("-d", "--deseq2", action="store_true",
                         help="Generate R code for using DESeq2 to identify differentially expressed peaks")

--- a/scripts/pints_normalizer
+++ b/scripts/pints_normalizer
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 # coding=utf-8
 
-#  PINTS: Peak Identifier for Nascent Transcripts Starts
-#  Copyright (c) 2019-2024 Yu Lab.
+#  PINTS: Peak Identifier for Nascent Transcript Starts
+#  Copyright (c) 2019-2025 Yu Lab.
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/scripts/pints_sample_qc
+++ b/scripts/pints_sample_qc
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 # coding=utf-8
 
-#  PINTS: Peak Identifier for Nascent Transcripts Starts
-#  Copyright (c) 2019-2024 Yu Lab.
+#  PINTS: Peak Identifier for Nascent Transcript Starts
+#  Copyright (c) 2019-2025 Yu Lab.
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/scripts/pints_visualizer
+++ b/scripts/pints_visualizer
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 # coding=utf-8
 
-#  PINTS: Peak Identifier for Nascent Transcripts Starts
-#  Copyright (c) 2019-2024 Yu Lab.
+#  PINTS: Peak Identifier for Nascent Transcript Starts
+#  Copyright (c) 2019-2025 Yu Lab.
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/tests/functional_test.py
+++ b/tests/functional_test.py
@@ -1,4 +1,4 @@
-#  PINTS: Peak Identifier for Nascent Transcripts Starts
+#  PINTS: Peak Identifier for Nascent Transcript Starts
 #  Copyright (c) 2019-2023 Yu Lab.
 #
 #  This program is free software: you can redistribute it and/or modify


### PR DESCRIPTION
- [Changed]: PINTS now includes signals from all chromosomes by default, irrespective of their naming convention. This change (addressing issue #26) enhances support for diverse genomic datasets, such as plant genomes which often utilize different naming schemes. To revert to the previous behavior of analyzing only chromosomes starting with "chr", use the `--chromosome-start-with chr` flag.
- [Changed]: For experiments with replicates, PINTS now automatically merges these replicates and performs peak calling on the combined signal. Users wishing to perform separate peak calls on individual replicates (the previous method) can specify the `--dont-merge-reps` option.
- [Added]: PINTS can act in a more sensitive mode (LRT+FC). To utilize the mode, please specify the `--sensitive` flag can be used.
- [Changed]: The description of PINTS has been updated across its various files.